### PR TITLE
Fix: Exclude transferred-out folios from overall XIRR calculation?

### DIFF
--- a/src/core/xirr.ts
+++ b/src/core/xirr.ts
@@ -60,7 +60,11 @@ export function computeXIRR(cashFlows: CashFlow[], guess = 0.1): number {
 }
 
 export function computeOverallXIRR(portfolios: PortfolioResult[]): number {
+  // Exclude schemes with no terminal positive cash flow (e.g. fully transferred-out
+  // folios where valuationValue = 0). Their orphaned negative flows — purchases with
+  // no corresponding closing value — corrupt the NPV and produce nonsensical rates.
   const merged: CashFlow[] = portfolios
+    .filter((p) => p.cashFlowSeries.cashFlows.some((cf) => cf.amount > 0))
     .flatMap((p) => p.cashFlowSeries.cashFlows)
     .sort((a, b) => a.date.getTime() - b.date.getTime())
   return computeXIRR(merged)


### PR DESCRIPTION
Fixes #1 

Added a `.filter()` in computeOverallXIRR to exclude any scheme whose cash flow series contains no positive cash flow before merging:

`.filter((p) => p.cashFlowSeries.cashFlows.some((cf) => cf.amount > 0))`

A scheme with no positive cash flows cannot produce a meaningful XIRR and its inclusion actively breaks the calculation for the rest of the portfolio. The new folio for the same fund is still included and correctly accounts for the full investment history via its own purchases